### PR TITLE
Ignore test/work directory from git and standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/work

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "standard": {
     "ignore": [
-
+      "test/work"
     ]
   }
 }


### PR DESCRIPTION
Hi, 

First of all, thanks for the project! I'm currently using it for Mac App Store app and really saves my time.

I found that standard fails because of JavaScript files inside `test/work` directory, so this pull request adds ignore add settings to ignore `test/work` from standard and also Git.