### PR TITLE
Automatically sign native Node addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ function signApplication (opts, callback) {
             childPaths.push(filePath)
             break
           case '.dylib': // dynamic library
+          case '.node': // native node addon
             childPaths.push(filePath)
             break
           case '.cstemp': // temporary file generated from past codesign


### PR DESCRIPTION
Native node addons should be automatically signed, as they're marked executable.
